### PR TITLE
Yaml Generation and Refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .gitcredentials
 apikey
 kubeconfig*
-*.yaml
-*.json
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gitcredentials
+apikey
+kubeconfig*
+*.yaml
+*.json

--- a/cluster.py
+++ b/cluster.py
@@ -20,10 +20,8 @@ class Cluster():
     def connect_to_cluster(self):
         """Connect to the cluster. Set API attributes."""
         config.load_kube_config(self.kubeconfig)
-        print("Connecting to Cluster API")
         self.apps_v1_api = client.AppsV1Api()
         self.core_v1_api = client.CoreV1Api()
-        print("Connected!")
 
     def get_pods_for_all_namespaces(self):
         """Return list of dicts of pod info.

--- a/cluster.py
+++ b/cluster.py
@@ -33,7 +33,7 @@ class Cluster():
         pod_list = []
         ret = self.core_v1_api.list_pod_for_all_namespaces(watch=False)
         for i in ret.items:
-            d = {}
+            d = dict()
             d["ip"] = i.status.pod_ip
             d["name"] = i.metadata.name
             d["namespace"] = i.metadata.namespace
@@ -51,7 +51,7 @@ class Cluster():
         deployment_list = []
         ret = self.apps_v1_api.list_deployment_for_all_namespaces(watch=False)
         for i in ret.items:
-            d = {}
+            d = dict()
             d["name"] = i.metadata.name
             d["namespace"] = i.metadata.namespace
             d["replicas"] = i.spec.replicas

--- a/cluster.py
+++ b/cluster.py
@@ -1,0 +1,68 @@
+"""Kubernetes Cluster API Class."""
+from kubernetes import client, config
+
+
+class Cluster():
+    """Define Cluster data and methods."""
+
+    def __init__(self, kubeconfig):
+        """Instantiate Cluster object.
+
+        Args:
+            kubeconfig: credential file for cluster
+
+        """
+        self.kubeconfig = kubeconfig
+        self.apps_v1_api = None
+        self.core_v1_api = None
+        self.connect_to_cluster()
+
+    def connect_to_cluster(self):
+        """Connect to the cluster. Set API attributes."""
+        config.load_kube_config(self.kubeconfig)
+        print("Connecting to Cluster API")
+        self.apps_v1_api = client.AppsV1Api()
+        self.core_v1_api = client.CoreV1Api()
+        print("Connected!")
+
+    def get_pods_for_all_namespaces(self):
+        """Return list of dicts of pod info.
+
+        Returns:
+            pod_list: list of dicts
+
+        """
+        pod_list = []
+        ret = self.core_v1_api.list_pod_for_all_namespaces(watch=False)
+        for i in ret.items:
+            d = {}
+            d["ip"] = i.status.pod_ip
+            d["name"] = i.metadata.name
+            d["namespace"] = i.metadata.namespace
+            pod_list.append(d)
+
+        return pod_list
+
+    def get_deployments_for_all_namespaces(self):
+        """Return list of dicts of deployment info.
+
+        Returns:
+            deployment_list: list of dicts
+
+        """
+        deployment_list = []
+        ret = self.apps_v1_api.list_deployment_for_all_namespaces(watch=False)
+        for i in ret.items:
+            d = {}
+            d["name"] = i.metadata.name
+            d["namespace"] = i.metadata.namespace
+            d["replicas"] = i.spec.replicas
+
+            container_list = []
+            for container in i.spec.template.spec.containers:
+                container_list.append(container.image)
+
+            d["containers"] = container_list
+            deployment_list.append(d)
+
+        return deployment_list

--- a/hld.py
+++ b/hld.py
@@ -1,0 +1,118 @@
+"""Use to construct the HLD from given information."""
+from ruamel.yaml import YAML
+yaml = YAML()
+
+
+class Component():
+    """Hold the information for fabrikate High-Level Deployment(HLD)."""
+    def __init__(self, name, generator="static", method="git"):
+        """Instantiate a Component object.
+
+        Args:
+            name: string name of component
+            generator: string type of manifest generation(default:static)
+            method: string type of retrieval (default:git)
+
+        """
+        self._name = name
+        self._generator = None
+        self._source = None
+        self._method = method
+        self._path = None
+        self._version = None
+        self._branch = None
+        self._hooks = None
+        self._repositories = None
+        self._subcomponents = None
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def generator(self):
+        return self._generator
+
+    @property
+    def source(self):
+        return self._source
+
+    @property
+    def method(self):
+        return self._method
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def branch(self):
+        return self._branch
+
+    @property
+    def hooks(self):
+        return self._hooks
+
+    @property
+    def repositories(self):
+        return self._repositories
+
+    @property
+    def subcomponents(self):
+        return self._subcomponents
+
+    @name.setter
+    def name(self, name):
+        self._name = name
+
+    @generator.setter
+    def generator(self, generator):
+        self._generator = generator
+
+    @source.setter
+    def source(self, source):
+        self._source = source
+
+    @method.setter
+    def method(self, method):
+        self._method = method
+
+    @path.setter
+    def path(self, path):
+        self._path = path
+
+    @version.setter
+    def version(self, version):
+        self._version = version
+
+    @branch.setter
+    def branch(self, branch):
+        self._branch = branch
+
+    @hooks.setter
+    def hooks(self, hooks):
+        self._hooks = hooks
+
+    @repositories.setter
+    def repositories(self, repositories):
+        self._repositories = repositories
+
+    @subcomponents.setter
+    def subcomponents(self, subcomponents):
+        self._subcomponents = subcomponents
+
+
+def generate_HLD(component, output):
+    """Create HLD yaml file.
+
+    Args:
+        component: Component object
+        output: filestream
+
+    """
+    yaml.register_class(Component)
+    yaml.dump(component, output)

--- a/hld.py
+++ b/hld.py
@@ -32,7 +32,7 @@ class Component():
 
     def asdict(self):
         """Return dict of Component."""
-        d = {}
+        d = dict()
         try:
             if self.subcomponents:
                 d = {key: value for key, value in self.__dict__.items()

--- a/hld.py
+++ b/hld.py
@@ -1,12 +1,12 @@
 """Use to construct the HLD from given information."""
 from copy import deepcopy
-from collections import OrderedDict
-from ruamel.yaml import YAML, representer
+from ruamel.yaml import YAML
 yaml = YAML()
 
 
 class Component():
     """Hold the information for fabrikate High-Level Deployment(HLD)."""
+
     def __init__(self, name, generator="static", method="git"):
         """Instantiate a Component object.
 
@@ -28,29 +28,29 @@ class Component():
         self.subcomponents = None
 
     # How the class is represented in yaml
-    yaml_tag= u'Component'
+    yaml_tag = u'Component'
 
     def asdict(self):
-        """Return dict of Component"""
+        """Return dict of Component."""
         d = {}
         try:
             if self.subcomponents:
-                d = {key:value for key,value in self.__dict__.items() if key != "subcomponents"}
+                d = {key: value for key, value in self.__dict__.items()
+                     if key != "subcomponents"}
                 d["subcomponents"] = []
                 for subcomponent in self.subcomponents:
                     d["subcomponents"].append(subcomponent.asdict())
-            
-        except AttributeError as e:
-            # verbose_print(e)
-            d = {key:value for key,value in self.__dict__.items()}
+
+        except AttributeError:
+            d = {key: value for key, value in self.__dict__.items()}
         return d
 
     def delete_none_attrs(self):
-        """Removes attributes with value of None."""
+        """Remove attributes with value of None."""
         attr_dict = deepcopy(self.__dict__)
 
         for key, value in attr_dict.items():
-            if value == None:
+            if value is None:
                 delattr(self, key)
 
     def prep(self):

--- a/hydrate.py
+++ b/hydrate.py
@@ -17,14 +17,14 @@ def count_first_word(dict_list, key):
         key: Used to obtain the values from each dictionary
 
     Returns:
-        dict(key:word, value:count)
+        dict(key:word, value:count) sorted by value desc. order
 
     """
     ret_count = dict()
     for item in dict_list:
         words = item[key].split("-")
         ret_count[words[0]] = ret_count.get(words[0], 0) + 1
-    return ret_count
+    return sort_dict_by_value(ret_count)
 
 
 def sort_dict_by_value(d):
@@ -91,15 +91,10 @@ if __name__ == '__main__':
     dep_counts = count_first_word(deployments, "name")
     pod_counts = count_first_word(pods, "name")
 
-    # Sort the word counts
-    verbose_print("Sorting the word counts...")
-    sorted_deps = sort_dict_by_value(dep_counts)
-    sorted_pods = sort_dict_by_value(pod_counts)
-
     # Create list of subcomponents
     verbose_print("Creating the list of subcomponents...")
     sub_list = []
-    for each in sorted_pods:
+    for each in pod_counts:
         sub_list.append(Component(each[0]))
 
     # Delete None attributes

--- a/hydrate.py
+++ b/hydrate.py
@@ -9,7 +9,7 @@ from cluster import Cluster
 from hld import Component, generate_HLD
 
 
-def word_counts(dict_list, key):
+def count_first_word(dict_list, key):
     """Count the first word of each dict[key] in the list.
 
     Args:
@@ -77,21 +77,19 @@ if __name__ == '__main__':
     verbose_print = print if args.verbose else lambda *a, **k: None
     verbose_print("Printing verbosely...")
 
-    # Connect to Cluster
     verbose_print("Connecting to cluster...")
     my_cluster = Cluster(args.kubeconfig)
     verbose_print("Connected!")
     deployments = my_cluster.get_deployments_for_all_namespaces()
     pods = my_cluster.get_pods_for_all_namespaces()
 
-    # Create Component
     verbose_print("Creating Component object...")
     my_component = Component(args.name)
 
     # Get first word counts
     verbose_print("Getting first word counts...")
-    dep_counts = word_counts(deployments, "name")
-    pod_counts = word_counts(pods, "name")
+    dep_counts = count_first_word(deployments, "name")
+    pod_counts = count_first_word(pods, "name")
 
     # Sort the word counts
     verbose_print("Sorting the word counts...")

--- a/hydrate.py
+++ b/hydrate.py
@@ -80,27 +80,25 @@ if __name__ == '__main__':
     verbose_print("Connecting to cluster...")
     my_cluster = Cluster(args.kubeconfig)
     verbose_print("Connected!")
+
+    verbose_print("Collecting information from the cluster...")
     deployments = my_cluster.get_deployments_for_all_namespaces()
     pods = my_cluster.get_pods_for_all_namespaces()
 
     verbose_print("Creating Component object...")
     my_component = Component(args.name)
 
-    # Get first word counts
     verbose_print("Getting first word counts...")
     dep_counts = count_first_word(deployments, "name")
     pod_counts = count_first_word(pods, "name")
 
-    # Create list of subcomponents
     verbose_print("Creating the list of subcomponents...")
+    verbose_print("Deleting None attributes from subcomponents...")
     sub_list = []
     for each in pod_counts:
-        sub_list.append(Component(each[0]))
-
-    # Delete None attributes
-    verbose_print("Deleting None attributes from subcomponents...")
-    for sub in sub_list:
-        sub.delete_none_attrs()
+        s = Component(each[0])
+        s.delete_none_attrs()
+        sub_list.append(s)
 
     my_component.subcomponents = sub_list
 

--- a/hydrate.py
+++ b/hydrate.py
@@ -72,6 +72,15 @@ if __name__ == '__main__':
     verbose_print = print if args.verbose else lambda *a, **k: None
     verbose_print("Printing verbosely...")
 
-    config.load_kube_config('kubeconfig')
-    get_pods_for_all_namespaces()
-    get_deployments_for_all_namespaces()
+    config.load_kube_config(args.kubeconfig)
+    
+    print("Connecting to Cluster API")
+    api = client.AppsV1Api()
+    print("Connected!")
+
+    with open('deployments.json','w+') as out:
+        ret = api.list_deployment_for_all_namespaces(watch=False)
+        for i in ret.items:
+            out.write(str(i))
+    #get_pods_for_all_namespaces()
+    #get_deployments_for_all_namespaces()

--- a/hydrate.py
+++ b/hydrate.py
@@ -78,26 +78,39 @@ if __name__ == '__main__':
     verbose_print("Printing verbosely...")
 
     # Connect to Cluster
+    verbose_print("Connecting to cluster...")
     my_cluster = Cluster(args.kubeconfig)
+    verbose_print("Connected!")
     deployments = my_cluster.get_deployments_for_all_namespaces()
     pods = my_cluster.get_pods_for_all_namespaces()
 
     # Create Component
+    verbose_print("Creating Component object...")
     my_component = Component(args.name)
 
     # Get first word counts
+    verbose_print("Getting first word counts...")
     dep_counts = word_counts(deployments, "name")
     pod_counts = word_counts(pods, "name")
 
     # Sort the word counts
+    verbose_print("Sorting the word counts...")
     sorted_deps = sort_dict_by_value(dep_counts)
     sorted_pods = sort_dict_by_value(pod_counts)
 
+    # Create list of subcomponents
+    verbose_print("Creating the list of subcomponents...")
     sub_list = []
     for each in sorted_pods:
         sub_list.append(Component(each[0]))
 
+    # Delete None attributes
+    verbose_print("Deleting None attributes from subcomponents...")
+    for sub in sub_list:
+        sub.delete_none_attrs()
+
     my_component.subcomponents = sub_list
 
+    verbose_print("Writing component.yaml...")
     with open("component.yaml", "w") as of:
         generate_HLD(my_component, of)

--- a/hydrate.py
+++ b/hydrate.py
@@ -5,7 +5,7 @@ Functions:
     - get_deployments_for_all_namespaces()
 """
 from kubernetes import client, config
-from github import Github
+from ruamel.yaml import YAML
 import argparse
 import os
 
@@ -82,11 +82,4 @@ if __name__ == '__main__':
     verbose_print = print if args.verbose else lambda *a, **k: None
     verbose_print("Printing verbosely...")
 
-    with open('apikey') as f:
-        api_key = f.read()
-    g = Github(api_key)
     
-    print("Searching...")
-    repositories = g.search_repositories(query="fabrikate in:name", sort='stars')
-    for repo in repositories:
-        print(repo)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="hydrate",
+    version="0.1.0",
+    author='andrewDoing',
+    author_email='andrew.doing@mst.edu',
+    description="A package to generate an HLD for your kubernetes cluster",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/andrewDoing/hydrate",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/templates/config-template.yaml
+++ b/templates/config-template.yaml
@@ -1,0 +1,4 @@
+config:
+namespace:
+injectNamespace:
+subcomponents:

--- a/templates/hld-template.yaml
+++ b/templates/hld-template.yaml
@@ -1,0 +1,14 @@
+name:
+type:
+source:
+method:
+path:
+version:
+branch:
+hooks:
+  before-install:
+  before-generate:
+  after-install:
+  after-generate:
+repositories:
+subcomponents:


### PR DESCRIPTION
https://github.com/andrewDoing/hydrate/issues/2

With this PR, hydrate will be able to generate a component.yaml usable with Fabrikate from a given cluster.

The fields are populated by the first words found in the names of the deployments and pods. It's a simple placeholder solution which has room for improvement.

This PR also includes some refactoring, mainly the usage of multiple python files.