### PR TITLE
Add no match deployments to HLD generation

### DIFF
--- a/hydrate/cluster.py
+++ b/hydrate/cluster.py
@@ -1,6 +1,7 @@
 """Kubernetes Cluster API Class."""
 from kubernetes import client, config
 from .component import Component
+import re
 
 
 class Cluster():
@@ -16,7 +17,8 @@ class Cluster():
         self.kubeconfig = kubeconfig
         self.apps_v1_api = None
         self.core_v1_api = None
-        self.namespaced_pods = {}
+        self.namespaced_pods = dict()
+        self.namespaced_deployments = dict()
 
     def connect_to_cluster(self):
         """Connect to the cluster. Set API attributes."""
@@ -32,23 +34,48 @@ class Cluster():
 
         """
         components = []
+        default_deps = self.get_namespaced_deployments("default")
         namespaces = self.get_namespaces()
         namespaces = self.remove_defaults(namespaces)
-        # Scenario where cluster contains namespaces other than default ones
+        # Scenario where cluster applications live in namespaces
         if namespaces:
-            components = [namespace for namespace in namespaces]
-            components = [get_first_word(comp) for comp in components]
-            components = [Component(name) for name in components]
-        # Scenario where cluster applications all live in the default namespace
-        else:
-            pods = self.get_namespaced_pods("default")
-            components = self.process_cluster_objects(pods)
+            first_words = [get_first_word(name) for name in namespaces]
+            components.extend([Component(word) for word in first_words])
+        # Scenario where cluster applications live in default
+        if default_deps:
+            dep_names = [
+                re.sub(r'-deployment', '', dep) for dep in default_deps]
+            components.extend([Component(n) for n in dep_names])
+
         return components
+
+    def get_statefulsets(self):
+        """Query the cluster for statefulsets."""
+        ret = self.apps_v1_api.list_stateful_set_for_all_namespaces()
+        with open("statefulsets.json", "w") as of:
+            of.write(dict(ret))
 
     def get_namespaces(self):
         """Query the cluster for namespaces."""
         ret = self.core_v1_api.list_namespace()
         return [i.metadata.name for i in ret.items]
+
+    def get_namespaced_deployments(self, namespace):
+        """Store the list of deployments in the namespace.
+
+        Args:
+            namespace: The namespace to look in.
+
+        Return:
+            deployment_list: list of pods found in the namespace.
+        """
+        if namespace in self.namespaced_deployments:
+            return self.namespaced_deployments[namespace]
+        else:
+            ret = self.apps_v1_api.list_namespaced_deployment(namespace)
+            deployment_list = [i.metadata.name for i in ret.items]
+            self.namespaced_pods[namespace] = deployment_list
+            return deployment_list
 
     def get_namespaced_pods(self, namespace):
         """Store the list of pods in the namespace.

--- a/hydrate/component.py
+++ b/hydrate/component.py
@@ -66,10 +66,37 @@ class Component():
                 delattr(self, key)
 
 
+def match_components(repo_components, cluster_components):
+    """Match cluster and repo components."""
+    subcomponents = []
+    category_indeces = []
+    rc = repo_components
+    cc = cluster_components
+    full_matches, fm_leftovers = get_full_matches(rc, cc)
+
+    # Indeces are determined by the length of the previous category
+    if full_matches:
+        subcomponents.extend(full_matches)
+        category_indeces.append((0, "Full Match Components"))
+
+    if fm_leftovers:
+        subcomponents.extend(fm_leftovers)
+        category_indeces.append((len(full_matches), "No Match Deployments"))
+
+    return subcomponents, category_indeces
+
+
 def get_full_matches(repo_components, cluster_components):
-    """Return the Fabrikate Components that fully match the cluster."""
+    """Determine which components fully match the cluster.
+
+    Returns:
+        full_matches: list of components
+        leftovers: list of components
+
+    """
     full_matches = []
     cluster_set = set()
+    leftovers = None
     for cc in cluster_components:
         cluster_set.add(cc.name)
     for rc in repo_components:
@@ -81,5 +108,6 @@ def get_full_matches(repo_components, cluster_components):
 
     if cluster_set:
         print("Leftover deployments in cluster: {}".format(cluster_set))
+        leftovers = [cc for cc in cluster_components if cc.name in cluster_set]
 
-    return full_matches
+    return full_matches, leftovers

--- a/hydrate/hld.py
+++ b/hydrate/hld.py
@@ -1,18 +1,28 @@
 """Use to construct the High-Level Deployment."""
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml import YAML
 yaml = YAML()
 
+OFFSET = 2
 
-def generate_HLD(component, output):
+
+def generate_HLD(component, output, comment_indeces=None):
     """Create HLD yaml file.
 
     Args:
         component: Component object
         output: filestream
+        comment_indeces: List of tuples (index, comment text)
 
     """
     component.delete_none_attrs()
-    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.indent(mapping=2, sequence=4, offset=OFFSET)
     d = component.asdict()
+    if comment_indeces:
+        d = CommentedMap(d)
+        lst = CommentedSeq(d["subcomponents"])
+        for idx, comment in comment_indeces:
+            lst.yaml_set_comment_before_after_key(idx, comment, OFFSET)
+        d["subcomponents"] = lst
 
     yaml.dump(d, output)

--- a/hydrate/scrape.py
+++ b/hydrate/scrape.py
@@ -6,7 +6,7 @@ from .component import Component
 
 # URL to the Fabrikate Component Definitions
 FAB_DEFS_URL = "https://github.com/microsoft/fabrikate-definitions"
-FAB_DEFS_API = "https://api.github.com/repos/microsoft/fabrikate-definitions/contents/definitions"
+FAB_DEFS_API = "https://api.github.com/repos/microsoft/fabrikate-definitions/contents/definitions"  # noqa
 
 
 def get_repo_components():

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -43,13 +43,14 @@ class TestCluster():
         mock_client.CoreV1Api.assert_called_once()
 
     tst_namespaces = ["elasticsearch", "istio", "jaeger"]
-    tst_pods = ["elasticsearch-pod", "istio-pod", "jaeger-pod"]
+    tst_deps = ["elasticsearch-dep", "istio-dep", "jaeger-dep"]
 
-    @pytest.mark.parametrize("tst_namespaces, tst_pods",
-                             [(tst_namespaces, None),
-                              (None, tst_pods)])
+    @pytest.mark.parametrize("tst_namespaces, tst_deps",
+                             [(tst_namespaces, tst_deps),
+                              (tst_namespaces, None),
+                              (None, tst_deps)])
     def test_get_components(self, mocker, cluster_connection,
-                            tst_namespaces, tst_pods):
+                            tst_namespaces, tst_deps):
         """Test the method get_components."""
         mock_get_namespaces = mocker.patch(
             "hydrate.cluster.Cluster.get_namespaces",
@@ -58,23 +59,22 @@ class TestCluster():
             "hydrate.cluster.Cluster.remove_defaults",
             return_value=tst_namespaces)
         mock_get_first_word = mocker.patch("hydrate.cluster.get_first_word")
-        mock_get_namespaced_pods = mocker.patch(
-            "hydrate.cluster.Cluster.get_namespaced_pods",
-            return_value=tst_pods)
-        mock_process_cluster_objects = mocker.patch(
-            "hydrate.cluster.Cluster.process_cluster_objects",
-            return_value=tst_pods)
+        mock_get_namespaced_deployments = mocker.patch(
+            "hydrate.cluster.Cluster.get_namespaced_deployments",
+            return_value=tst_deps
+        )
+        mock_re_sub = mocker.patch("hydrate.cluster.re.sub")
 
         components = cluster_connection.get_components()
 
         assert components
+        mock_get_namespaced_deployments.assert_called_once()
         mock_get_namespaces.assert_called_once()
         mock_remove_defaults.assert_called_once()
         if tst_namespaces:
             mock_get_first_word.assert_called()
-        else:
-            mock_get_namespaced_pods.assert_called_once()
-            mock_process_cluster_objects.assert_called_once()
+        if tst_deps:
+            mock_re_sub.assert_called()
 
     tst_get_namespaces = ["elasticsearch", "istio", "jaeger"]
     @pytest.mark.parametrize("tst_get_namespaces",

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -50,14 +50,23 @@ tst_repo_components = [Component("dep1-dep2"),
                        Component("dep4-dep5")]
 exp_full_matches = [Component("dep1-dep2"),
                     Component("dep3")]
+exp_leftovers = [Component("dep4"),
+                 Component("dep6")]
 
 
-@pytest.mark.parametrize('repo_components, cluster_components, expected',
+@pytest.mark.parametrize('''repo_components, cluster_components,
+                            expected_fm, expected_leftos''',
                          [(tst_repo_components,
                            tst_cluster_components,
-                           exp_full_matches)])
-def test_get_full_matches(repo_components, cluster_components, expected):
+                           exp_full_matches,
+                           exp_leftovers)])
+def test_get_full_matches(repo_components, cluster_components,
+                          expected_fm, expected_leftos):
     """Test get_full_matches()."""
-    full_matches = get_full_matches(repo_components, cluster_components)
-    for fmc, exp in zip_longest(full_matches, exp_full_matches):
+    fms, leftos = get_full_matches(repo_components, cluster_components)
+
+    for fmc, exp in zip_longest(fms, exp_full_matches):
         assert fmc.name == exp.name
+
+    for lefto, exp_lefto in zip_longest(leftos, exp_leftovers):
+        assert lefto.name == exp_lefto.name


### PR DESCRIPTION
closes #41 

No match deployments will now be reflected in the component.yaml file. There are also comments in the yaml describing full matches and no matches.

```
name: hydrated-cluster
source: <source repository url>
method: git
path: ./manifests
subcomponents:
  # Full Match Components
  - name: elasticsearch-fluentd-kibana
    source: https://github.com/microsoft/fabrikate-definitions
    method: git
    path: definitions/fabrikate-elasticsearch-fluentd-kibana
  - name: istio
    source: https://github.com/microsoft/fabrikate-definitions
    method: git
    path: definitions/fabrikate-istio
  - name: jaeger
    source: https://github.com/microsoft/fabrikate-definitions
    method: git
    path: definitions/fabrikate-jaeger
  # No Match Deployments
  - name: spring-boot-api
    source: <source repository url>
    method: git
  - name: spring-boot-ui
    source: <source repository url>
    method: git
```